### PR TITLE
Replace time with std::time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,3 @@ description = "Calculate progress of your iterators"
 repository = "https://github.com/rory/iter-progress-rs"
 keywords = [ "iterator" ]
 readme = "README.md"
-
-[dependencies]
-time = "^0.1"


### PR DESCRIPTION
Was making per_sec stuff be subsecond accurate at first but that made tests which rely on division by zero to fail
